### PR TITLE
Update transforms.py

### DIFF
--- a/tools/image/transforms.py
+++ b/tools/image/transforms.py
@@ -13,7 +13,7 @@ class Normalize(nn.Module):
     def __init__(self, mean=default_statistics.mean, std=default_statistics.std, dtype=torch.float):
        super().__init__()
        self.mean = torch.tensor(mean, dtype=dtype)
-       self.std = torch.tensor(mean, dtype=dtype)
+       self.std = torch.tensor(std, dtype=dtype)
 
 
     def forward(self, batch):


### PR DESCRIPTION
BUG: In Normalize Init

Fixed init to use **std** instead of previously **mean** 

It is at this stage unclear to me how dramatic the impact of this is. Looks like the Normalisation class is not used during inference. I think you mainly use normalize_batch just as a function